### PR TITLE
Fix: router 변경 및 회원 가입 UNI 키 예외 처리

### DIFF
--- a/controller/user/Cuser.js
+++ b/controller/user/Cuser.js
@@ -90,6 +90,18 @@ exports.userRegister = async (req, res) => {
 
     console.log("User Model:", User);
 
+    // phoneNum 중복 확인
+    const existingUserByPhoneNum = await User.findOne({ where: { phoneNum } });
+    if (existingUserByPhoneNum) {
+      return res.status(409).json({ error: '이미 사용 중인 전화번호입니다.' });
+    }
+
+    // email 중복 확인
+    const existingUserByEmail = await User.findOne({ where: { email } });
+    if (existingUserByEmail) {
+      return res.status(409).json({ error: '이미 사용 중인 이메일입니다.' });
+    }
+
     // loginId 정규표현식 검사(가능: 영어소문자/숫자, 6~12 글자)
     const loginIdRegex = /^[a-z0-9]{6,12}$/;
     if (!loginIdRegex.test(loginId))
@@ -230,9 +242,6 @@ exports.checkPassword = async (req, res) => {
     const { userId } = req.session.user;
     const { userPw } = req.body;
 
-    console.log(req.session.user.userId);
-    console.log(userPw);
-
     // userId, userPw가 제공되지 않았거나 잘못된 경우 처리
     if (!userId || !userPw) {
       return res.status(400).json({ error: '사용자 ID와 비밀번호가 필요합니다.' });
@@ -302,7 +311,7 @@ exports.updateUser = async (req, res) => {
     // 성공 응답 시 userPw 제외
     const updatedUser = { ...user.toJSON() };
     delete updatedUser.userPw; // 비밀번호는 응답에서 제외
-    
+
     // 수정된 정보를 세션에도 저장
     req.session.user = {
       ...req.session.user,
@@ -328,7 +337,7 @@ exports.updateUser = async (req, res) => {
 
 // 회원 조회
 exports.getUser = async (req, res) => {
-  console.log("req >>>>> ",req.session);
+  console.log("req >>>>> ", req.session);
   try {
     const { userId } = req.session.user;
 

--- a/routes/user/user.js
+++ b/routes/user/user.js
@@ -9,13 +9,13 @@ router.get('/login', controller.userLogin);
 router.post('/register', controller.userRegister);
 
 // 로그인 아이디 중복 체크
-router.get('/checkLoginid', controller.checkDuplicatedLoginid);
+router.post('/checkLoginid', controller.checkDuplicatedLoginid);
 
 // 로그인 닉네임 중복 체크
-router.get('/checkNickname', controller.checkDuplicatedNickname);
+router.post('/checkNickname', controller.checkDuplicatedNickname);
 
 // 비밀번호 일치 확인
-router.get('/checkPassword', controller.checkPassword);
+router.post('/checkPassword', controller.checkPassword);
 
 // 로그아웃
 router.get('/logout', controller.userLogout);


### PR DESCRIPTION
- user 중 checkDuplicatedLoginid, checkDuplicatedNickname, checkPassword get에서 post로 변경
- userRegister(회원가입) 시 email, phoneNum UNI 키 중복 예외 처리